### PR TITLE
add autoprefixer to css processing

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -20,11 +20,12 @@ gulp.task 'babel', ['prepare'], taskRequire './tasks/scripts/babel'
 # Get components via Bower
 gulp.task 'bower', taskRequire './tasks/bower/bower'
 
-# build the app
+# Build the app
 gulp.task 'build', ['spa', 'fonts', 'images'], taskRequire './tasks/build'
 
 # Generate CHANGELOG
 gulp.task 'changelog', ['normalizeComponents', 'stats'], taskRequire './tasks/changelog/changelog'
+
 # Clean all build directories
 gulp.task 'clean:bower', taskRequire './tasks/clean/cleanBower'
 
@@ -38,7 +39,12 @@ gulp.task 'coffeeScript', ['prepare'], taskRequire './tasks/scripts/coffeeScript
 gulp.task 'css', ['prepare'], taskRequire './tasks/styles/css'
 
 # Default build
-gulp.task 'default', [].concat(if runServer then ['server'] else ['build']).concat(if runWatch then ['watch'] else []).concat(if runSpecs then ['test'] else []).concat(if showHelp then ['help'] else [])
+gulp.task 'default',
+	[]
+	.concat(if runServer then ['server'] else ['build'])
+	.concat(if runWatch then ['watch'] else [])
+	.concat(if runSpecs then ['test'] else [])
+	.concat(if showHelp then ['help'] else [])
 
 # Deploy
 gulp.task 'locationDeploy', taskRequire './tasks/deploy/locationDeploy'

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "node": ">=0.10.0"
   },
   "devDependencies": {
+    "autoprefixer": "^6.3.5",
     "bower": "^1.7.2",
     "browser-sync": "^2.8.2",
     "coffee-script": "^1.7.1",
@@ -44,6 +45,7 @@
     "gulp-newer": "^0.5.0",
     "gulp-ng-annotate": "^1.1.0",
     "gulp-ng-classify": "^4.0.0",
+    "gulp-postcss": "^6.1.0",
     "gulp-protractor": "^1.0.0",
     "gulp-rev": "^6.0.1",
     "gulp-sass": "^2.0.4",

--- a/src/app/app.less
+++ b/src/app/app.less
@@ -1,0 +1,15 @@
+// Here's a file which doesn't really style anything, but is in place to make
+// sure that building/compiling/processing the styles works ok.
+
+// This LESS selector should get expanded into:
+// .masthead .text-muted {...}
+// And it should have the vendor prefixes in place for flexbox and user-select.
+@angular-color: #a23d30;
+
+.masthead {
+	.text-muted {
+		color: @angular-color;
+		display: flex;
+		user-select: none;
+	}
+}

--- a/tasks/styles/styles.coffee
+++ b/tasks/styles/styles.coffee
@@ -1,8 +1,10 @@
+autoprefixer = require 'autoprefixer'
 browserSync = require 'browser-sync'
 {DIST_DIRECTORY, TEMP_DIRECTORY, STYLES_MIN_DIRECTORY, STYLES_MIN_FILE} = require '../constants'
 {isProd, injectCss} = require '../options'
 path = require 'path'
-templateOptions       = require '../templateOptions'
+postcss = require 'gulp-postcss'
+templateOptions = require '../templateOptions'
 {STYLES} = require '../../config/styles'
 
 module.exports = (gulp, plugins) -> ->
@@ -16,6 +18,13 @@ module.exports = (gulp, plugins) -> ->
 	src =
 		gulp
 			.src sources, {cwd: TEMP_DIRECTORY, nodir: true}
+			.on 'error', onError
+
+			# Now that we have all the preprocessor compilation done, we can perform
+			# any processing that needs to happen to the raw CSS output.
+			.pipe postcss([
+				autoprefixer(browsers: ['last 2 versions'])
+			])
 			.on 'error', onError
 
 	return if isProd


### PR DESCRIPTION
- adds postcss and autoprefixer packages
- applies autoprefixer with a sane example config
- tiny formatting tweaks to gulpfile.coffee
- adds a test less file to the app which gets compiled and autoprefixed